### PR TITLE
Secure SQL command

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,11 +8,17 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '22 21 * * 3'
+  workflow_call:
+    inputs:
+      languages:
+        description: "JSON array of languages"
+        required: false
+        type: string
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
@@ -21,25 +27,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [actions, csharp]
+        language: ${{ fromJson(inputs.languages || '["actions","csharp"]') }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Initialize CodeQL (C#)
-      if: matrix.language == 'csharp'
+
+    - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        languages: csharp
-        build-mode: autobuild
+        languages: ${{ matrix.language }}
         queries: +security-extended
 
-    - name: Initialize CodeQL (Actions)
-      if: matrix.language == 'actions'
-      uses: github/codeql-action/init@v3
-      with:
-        languages: actions
-        queries: +security-extended
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/simple-api/DataAccessLayer.cs
+++ b/simple-api/DataAccessLayer.cs
@@ -6,10 +6,11 @@ public class DataAccessLayer
 {
     public bool UpdateUserInformation(UserInformation username)
     {
-        var connection = new SqlConnection("ConnectionString");
-
-        var command = connection.CreateCommand();
-        command.CommandText = $"SELECT * FROM UserInformation WHERE Username = '{username.Username}'";
+        using var connection = new SqlConnection("ConnectionString");
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT * FROM UserInformation WHERE Username = @username";
+        command.Parameters.AddWithValue("@username", username.Username);
         command.Connection.Open();
         var rows = command.ExecuteNonQuery();
         return rows == 1;


### PR DESCRIPTION
## Summary
- remove swift/macOS special case
- allow reusing CodeQL workflow via `workflow_call`
- support any language in CodeQL workflow

## Testing
- `dotnet build --nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d44a44b08327a5aeacb13ab8a2e1